### PR TITLE
fixed > 2 tblproperties parsing

### DIFF
--- a/simple_ddl_parser/dialects/hql.py
+++ b/simple_ddl_parser/dialects/hql.py
@@ -44,7 +44,7 @@ class HQL:
     def p_multi_assigments(self, p):
         """multi_assigments : LP assigment
         | multi_assigments RP
-        | multi_assigments COMMA assigment RP"""
+        | multi_assigments COMMA assigment"""
         p_list = remove_par(list(p))
         p[0] = p_list[1]
         p[0].update(p_list[-1])

--- a/tests/test_hql_output_mode.py
+++ b/tests/test_hql_output_mode.py
@@ -1718,7 +1718,9 @@ def test_table_properties():
     STORED AS PARQUET LOCATION 'hdfs://test'
     TBLPROPERTIES (
     'parquet.compression'='SNAPPY',
-    'parquet.compression2'='SNAPPY2'
+    'parquet.compression2'='SNAPPY2',
+    'parquet.compression3'='SNAPPY3',
+    'parquet.compression4'='SNAPPY4'
     )
     """
     result = DDLParser(ddl).run(group_by_type=True, output_mode="hql")
@@ -1762,6 +1764,8 @@ def test_table_properties():
                 "tblproperties": {
                     "'parquet.compression'": "'SNAPPY'",
                     "'parquet.compression2'": "'SNAPPY2'",
+                    "'parquet.compression3'": "'SNAPPY3'",
+                    "'parquet.compression4'": "'SNAPPY4'",
                 },
             }
         ],


### PR DESCRIPTION
I noticed a problem with HQL parsing when there were more than 2 TBLPROPERTIES declared. 

Fixed expr for HQL parser.