### PR TITLE
fix parse set statement for lines with substr set

### DIFF
--- a/simple_ddl_parser/parser.py
+++ b/simple_ddl_parser/parser.py
@@ -130,7 +130,7 @@ class Parser:
         self.tables.append({"name": name, "value": value})
 
     def parse_set_statement(self):
-        if re.match(r"SET", self.line.upper()):
+        if re.match(r"SET ", self.line.upper()):
             self.set_was_in_line = True
             if not self.set_line:
                 self.set_line = self.line


### PR DESCRIPTION
Previously the SQL line `settling_xyz boolean,` was parsed as a SET statement. Now the word SET is being searched by regex.