### PR TITLE
Support Parse MYSQL DDL with 'COLLATE' option & fix class typo

### DIFF
--- a/simple_ddl_parser/ddl_parser.py
+++ b/simple_ddl_parser/ddl_parser.py
@@ -168,6 +168,14 @@ class DDLParser(Parser, Dialects):
             return True
         return False
 
+    def t_COLLATE(self, t: LexToken):
+        r"(?i:COLLATE|COLLATE)\b"
+        if not self.lexer.after_columns:
+            t.type = "COLLATE"
+        else:
+            t.type = "ID"
+        return self.set_last_token(t)
+
     def t_AUTOINCREMENT(self, t: LexToken):
         r"(?i:AUTO_INCREMENT|AUTOINCREMENT)\b"
         if not self.lexer.after_columns:

--- a/simple_ddl_parser/output/dialects.py
+++ b/simple_ddl_parser/output/dialects.py
@@ -86,7 +86,7 @@ class SparkSQL(Dialect):
 
 @dataclass
 @dialect(name="mysql")
-class MySSQL(Dialect):
+class MySQL(Dialect):
     engine: Optional[str] = field(
         default=None, metadata={"exclude_if_not_provided": True}
     )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -592,3 +592,43 @@ def test_column_index():
     ]
 
     assert result == expected
+
+
+def test_table_properties():
+    ddl = """CREATE TABLE `posts`(
+        `integer_column__index` INT NOT NULL INDEX
+    ) ENGINE=InnoDB AUTO_INCREMENT=4682 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='test';"""
+
+    result = DDLParser(ddl).run(output_mode="mysql")
+    expected = [
+        {
+            "alter": {},
+            "checks": [],
+            "auto_increment": "4682",
+            "columns": [
+                {
+                    "check": None,
+                    "default": None,
+                    "index": True,
+                    "name": "`integer_column__index`",
+                    "nullable": False,
+                    "references": None,
+                    "size": None,
+                    "type": "INT",
+                    "unique": False,
+                }
+            ],
+            "comment": "'test'",
+            "default_charset": "utf8mb4",
+            "engine": "InnoDB",
+            "index": [],
+            "partitioned_by": [],
+            "primary_key": [],
+            "schema": None,
+            "table_name": "`posts`",
+            "tablespace": None,
+            "table_properties": {"collate": "utf8mb4_unicode_ci"}
+        }
+    ]
+    assert result == expected
+


### PR DESCRIPTION
Hello,

This Pull Request addresses the following two issues:
Fix Issue #265:

Problem Description: This resolves the bug reported in Issue #265.
Solution: Identified the cause of the bug and corrected the relevant code. This ensures the affected functionality works as intended.
Correct Class Name Typo:

Problem Description: A typo was found in a specific class name within the codebase.
Solution: Corrected the typo to improve code readability and maintain consistency.
I hope this contribution helps improve the quality of the project. I would appreciate it if you could review the changes.

Please let me know if there are any further adjustments or feedback needed.

Thank you.